### PR TITLE
Don't use ./.conjurrc by default anymore

### DIFF
--- a/lib/conjur/config.rb
+++ b/lib/conjur/config.rb
@@ -37,11 +37,11 @@ module Conjur
           homefile = File.expand_path "~/.conjurrc"
           pwdfile = File.expand_path ".conjurrc"
           if homefile != pwdfile && File.file?(pwdfile)
-            $stderr.puts "WARNING: .conjurrc file from current directory is " +
-                "used. This behaviour is deprecated. Use ENV['CONJURRC'] to " +
-                "explicitly define custom configuration file if needed"
+            $stderr.puts """NOTE:\t.conjurrc file detected in the current directory.\n"\
+                "\tIt's no longer consulted in this version. Please explicitly\n"\
+                "\tset CONJURRC=./.conjurrc if you're sure you want to use it."
           end
-          [ homefile, pwdfile ]
+          [ homefile ]
         end
       end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -16,7 +16,7 @@ describe Conjur::Config do
       ENV['HOME'] = realhome
     end
 
-    let(:deprecation_warning) { "WARNING: .conjurrc file from current directory is used. This behaviour is deprecated. Use ENV['CONJURRC'] to explicitly define custom configuration file if needed" }
+    let(:deprecation_warning) { /\.conjurrc/ }
 
     shared_examples "no deprecation warning" do
       it "does not issue a deprecation warning" do
@@ -36,7 +36,6 @@ describe Conjur::Config do
 
       it { is_expected.to include('/etc/conjur.conf') }
       it { is_expected.to include("#{homedir}/.conjurrc") }
-      it { is_expected.to include('.conjurrc') }
 
       before do
         allow(File).to receive(:expand_path).and_call_original
@@ -47,6 +46,10 @@ describe Conjur::Config do
         before { allow(File).to receive(:file?).with('.conjurrc').and_return true }
         it "Issues a deprecation warning" do 
           expect { subject }.to write(deprecation_warning).to(:stderr)
+        end
+
+        it "doesn't use the file" do
+          expect(subject).to_not include '.conjurrc'
         end
 
         context "but the current directory is home" do


### PR DESCRIPTION
We've had a deprecation warning for that for over a year now.
Given it's a potential security problem, let's squash it (while still giving a reasonable warning).