### PR TITLE
[#104945364] Fix --as-group and --as-role support in conjur policy load

### DIFF
--- a/acceptance-features/dsl/policy_owner.feature
+++ b/acceptance-features/dsl/policy_owner.feature
@@ -1,0 +1,24 @@
+Feature: Loading a policy can specify the policy's admin
+
+  Background:
+    Given I successfully run `conjur group create $ns/admin`
+    And a file named "policy.rb" with:
+    """
+policy 'test-policy-1.0' do
+end
+    """
+
+  Scenario: --as-group works
+    When I run `conjur policy load --as-group $ns/admin --collection $ns` interactively
+    And I pipe in the file "policy.rb"
+    And the exit status should be 0
+    When I run `conjur role members policy:$ns/test-policy-1.0`
+    Then the output from "conjur role members policy:$ns/test-policy-1.0" should match /group:.*$ns.admin/
+
+  Scenario: --as-role works
+    When I run `conjur policy load --as-role group:$ns/admin --collection $ns` interactively
+    And I pipe in the file "policy.rb"
+    And the exit status should be 0
+    When I run `conjur role members policy:$ns/test-policy-1.0`
+    Then the output from "conjur role members policy:$ns/test-policy-1.0" should match /group:.*$ns.admin/
+

--- a/acceptance-features/dsl/policy_owner.feature
+++ b/acceptance-features/dsl/policy_owner.feature
@@ -5,6 +5,7 @@ Feature: Loading a policy can specify the policy's admin
     And a file named "policy.rb" with:
     """
 policy 'test-policy-1.0' do
+  user "test_user"
 end
     """
 
@@ -22,3 +23,9 @@ end
     When I run `conjur role members policy:$ns/test-policy-1.0`
     Then the output from "conjur role members policy:$ns/test-policy-1.0" should match /group:.*$ns.admin/
 
+  Scenario: --as-group doesn't interfere with policy ownership of other resources
+    When I run `conjur policy load --as-group $ns/admin --collection $ns` interactively
+    And I pipe in the file "policy.rb"
+    And the exit status should be 0
+    When I run `conjur resource show user:test_user@$ns-test-policy-1-0 | jsonfield owner`
+    Then the output from "conjur resource show user:test_user@$ns-test-policy-1-0 | jsonfield owner" should match /policy:$ns.test-policy-1.0/

--- a/acceptance-features/dsl/resource_owner.feature
+++ b/acceptance-features/dsl/resource_owner.feature
@@ -1,0 +1,17 @@
+Feature: Resources created by a policy are owned by the policy
+
+  Background:
+    Given a file named "policy.rb" with:
+    """
+policy 'test-policy-1.0' do
+  resource 'webservice', 'web1'
+end
+    """
+
+  Scenario: resource is create with correct ownership
+    When I run `conjur policy load --collection $ns` interactively
+    And I pipe in the file "policy.rb"
+    And the exit status should be 0
+    When I run `conjur resource show webservice:$ns/test-policy-1.0/web1 | jsonfield owner`
+    Then the output from "conjur resource show webservice:$ns/test-policy-1.0/web1 | jsonfield owner" should match /policy:$ns.test-policy-1.0/
+

--- a/acceptance-features/step_definitions/cli.rb
+++ b/acceptance-features/step_definitions/cli.rb
@@ -19,3 +19,7 @@ Then /^it prints the path to temporary file which contains: '(.*)'$/ do |content
   actual_content=File.read(filename) rescue ""
   expect(actual_content).to match(content)
 end
+
+Then /^the output from "([^"]*)" should match \/([^\/]*)\/$/ do |cmd, expected|
+  assert_matching_output(expected, output_from(cmd))
+end

--- a/lib/conjur/dsl/runner.rb
+++ b/lib/conjur/dsl/runner.rb
@@ -194,6 +194,13 @@ module Conjur
 
         unless (obj = api.send(find_method, id)) && obj.exists?
           options = expand_options(options)
+
+          # create_resource and create_role expect :acting_as to
+          # specify the "owning" role.
+          if create_method == :create_resource || create_method == :create_role
+            options[:acting_as] = options.delete(:ownerid) if options[:ownerid]
+          end
+
           obj = if create_method == :create_variable
             #NOTE: it duplicates logic of "create_variable" method above
             #   https://basecamp.com/1949725/projects/4268938-api-version-4-x/todos/84972543-low-variable


### PR DESCRIPTION
Also, make sure bare resources created in a policy are owned by the policy.