### PR TITLE
[#110512828] Add support for expiration, host-factory, and audit-send

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in conjur.gemspec
 gemspec
 
-gem 'conjur-api', git: 'https://github.com/conjurinc/api-ruby.git', branch: 'master'
+gem 'conjur-api', git: 'https://github.com/conjurinc/api-ruby.git', branch: 'promote-plugins_151221'
 
 group :test, :development do
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in conjur.gemspec
 gemspec
 
-gem 'conjur-api', git: 'https://github.com/conjurinc/api-ruby.git', branch: 'promote-plugins_151221'
+gem 'conjur-api', git: 'https://github.com/conjurinc/api-ruby.git', branch: 'master'
 
 group :test, :development do
   gem 'pry'

--- a/conjur.gemspec
+++ b/conjur.gemspec
@@ -35,7 +35,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'io-grab', '~> 0.0.1'
   gem.add_development_dependency 'json_spec'
-  # For cukes
-  gem.add_development_dependency 'conjur-asset-audit-send'
-  gem.add_development_dependency 'conjur-asset-host-factory'
 end

--- a/lib/conjur/cli.rb
+++ b/lib/conjur/cli.rb
@@ -69,8 +69,8 @@ module Conjur
 
       def load_plugins
         # These used to be plugins but now they are in the core CLI
-        plugins = Conjur::Config.plugins - %w(layer pubkeys)
-        
+        plugins = Conjur::Config.plugins - %w(audit-send host-factory layer pubkeys)
+        puts "plugins: #{plugins.inspect}"
         plugins.each do |plugin|
           begin
             filename = "conjur-asset-#{plugin}"

--- a/lib/conjur/cli.rb
+++ b/lib/conjur/cli.rb
@@ -70,7 +70,6 @@ module Conjur
       def load_plugins
         # These used to be plugins but now they are in the core CLI
         plugins = Conjur::Config.plugins - %w(audit-send host-factory layer pubkeys)
-        puts "plugins: #{plugins.inspect}"
         plugins.each do |plugin|
           begin
             filename = "conjur-asset-#{plugin}"

--- a/lib/conjur/command/audit.rb
+++ b/lib/conjur/command/audit.rb
@@ -138,6 +138,18 @@ class Conjur::Command
         id = full_resource_id(require_arg args, "resource")
         api.audit_resource(id, options){|es| show_audit_events es, options}
       end 
+
+      audit.desc "Send custom event(s) to audit system"
+      audit.long_desc "Send custom event(s) to audit system. Events should be provided in JSON format, describing either single hash or array of hashes."
+      audit.arg_name "( json_string | STDIN )"
+      audit.command :send do |c| 
+        c.action do |global_options, options, args|
+          json = ( args.shift || STDIN.read )
+          api.audit_send json 
+          puts "Events sent successfully"
+        end
+      end
+
     end
   end
 end

--- a/lib/conjur/command/host_factories.rb
+++ b/lib/conjur/command/host_factories.rb
@@ -1,0 +1,161 @@
+#
+# Copyright (C) 2014 Conjur Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+class Conjur::Command::HostFactories < Conjur::Command
+  desc "Manage host factories"
+
+  command :hostfactory do |hf|
+    hf.desc "Create a new host factory"
+    hf.arg_name "id"
+    hf.command :create do |c|
+      acting_as_option(c)
+
+      #c.arg_name "layer"
+      #c.desc "A space-delimited list of layers to which new hosts will belong"
+      #c.flag [:l, :layer]
+
+      c.action do |global_options,options,args|
+        id = require_arg(args, 'hostfactory')
+        
+        unless options[:ownerid]
+          exit_now! "Use --as-group or --as-role to indicate the host factory role"
+        end
+        
+        layers = (options[:layer] || "").split(/\s/)
+        layers.each do |layer|
+          exit_now! "Layer '#{layer}' does not exist" unless api.layer(layer).exists?
+        end
+        
+        command_options = options.dup
+        command_options[:layers] = layers
+        command_options[:roleid] = options[:ownerid]
+          
+        host_factory = api.create_host_factory id, command_options
+        display host_factory
+      end
+    end
+
+    hf.desc "Show a host factory"
+    hf.arg_name "id"
+    hf.command :show do |c|
+      c.action do |global_options,options,args|
+        id = require_arg(args, 'id')
+        display(api.host_factory(id), options)
+      end
+    end
+
+    hf.desc "List host factories"
+    hf.command :list do |c|
+      command_options_for_list c
+      c.action do |global_options, options, args|
+        command_impl_for_list global_options, options.merge(kind: "host_factory"), args
+      end
+    end
+
+    hf.desc "Operations on tokens"
+    hf.long_desc <<-DESC
+This command creates one or more identical tokens. A token is always created with an 
+expiration time, which by default is 1 hour from now. The expiration time can be customized
+with command arguments specifying the number of minutes, hours, days for which the token
+will be valid.
+
+By default, this command creates one token. Optionally, it can be used to create multiple identical tokens.
+    DESC
+    hf.command :tokens do |tokens|
+      
+      tokens.desc "Create one or more tokens"
+      tokens.arg_name "hostfactory"
+      tokens.command :create do |c|
+        c.arg_name "duration in minutes"
+        c.desc "Number of minutes from now in which the token will expire"
+        c.flag [:"duration-minutes"]
+
+        c.arg_name "duration in hours"
+        c.desc "Number of hours from now in which the token will expire"
+        c.flag [:"duration-hours"]
+          
+        c.arg_name "duration in days"
+        c.desc "Number of days from now in which the token will expire"
+        c.flag [:"duration-days"]
+        
+        c.arg_name "count"
+        c.desc "Number of identical tokens to create"
+        c.flag [:c, :count]
+          
+        c.action do |global_options,options,args|
+          id = require_arg(args, 'hostfactory')
+
+          duration = 0
+          %w(duration-minutes duration-hours duration-days).each do |d|
+            if t = options[d.to_sym]
+              duration += t.to_i.send(d.split('-')[-1])
+            end
+          end
+          if duration == 0
+            duration = 1.hour
+          end
+          expiration = Time.now + duration
+          count = (options[:count] || 1).to_i
+          command_options = {}
+          
+          tokens = api.host_factory(id).create_tokens expiration, count, command_options
+          display tokens.map(&:to_json)
+        end
+      end
+
+      tokens.desc "Revoke (delete) a token"
+      tokens.arg_name "token"
+      tokens.command :revoke do |c|
+        c.action do |global_options,options,args|
+          token = require_arg(args, 'token')
+          
+          api.revoke_host_factory_token token
+          puts "Token revoked"
+        end
+      end
+      
+      tokens.desc "Show a token"
+      tokens.arg_name "token"
+      tokens.command :show do |c|
+        c.action do |global_options,options,args|
+          token = require_arg(args, 'token')
+          
+          display api.show_host_factory_token(token), options
+        end
+      end
+    end
+
+    hf.desc "Operations on hosts"
+    hf.command :hosts do |hosts|
+      hosts.desc "Use a token to create a host"
+      hosts.arg_name "token host-id"
+      hosts.command :create do |c|
+        c.action do |global_options,options,args|
+          token = require_arg(args, 'token')
+          id = require_arg(args, 'host-id')
+          
+          host = Conjur::API.host_factory_create_host token, id, options
+          display host
+        end
+      end
+    end
+  end
+end

--- a/lib/conjur/command/users.rb
+++ b/lib/conjur/command/users.rb
@@ -136,7 +136,7 @@ class Conjur::Command::Users < Conjur::Command
       c.flag [:p,:password]
 
       c.action do |global_options,options,args|
-        username, password = Conjur::Authn.read_credentials
+        username, password = Conjur::Authn.get_credentials
         new_password = options[:password] || prompt_for_password
 
         Conjur::API.update_password username, password, new_password

--- a/lib/conjur/command/variables.rb
+++ b/lib/conjur/command/variables.rb
@@ -154,6 +154,7 @@ class Conjur::Command::Variables < Conjur::Command
       end
     end
 
+    var.desc 'Set the expiration for a variable'
     var.command :expire do |c|
       c.arg_name "NOW"
       c.desc 'Set variable to expire immediately'
@@ -196,7 +197,8 @@ class Conjur::Command::Variables < Conjur::Command
       end
     end
 
-    var.desc 'List expiring variables. If no interval is specified, show all visible variables with an expiration.'
+    var.desc 'Display expiring variables'
+    var.long_desc 'Only variables that expire within the given duration are displayed. If no duration is provided, show all visible variables that are set to expire.'
     var.command :expirations do |c|
       c.arg_name 'DAYS'
       c.desc 'Display variables that expire within the given number of days'
@@ -225,7 +227,7 @@ class Conjur::Command::Variables < Conjur::Command
           duration = "P#{months.to_i}M"
         end
 
-        display api.variable_expirations
+        display api.variable_expirations(duration)
       end
     end
 

--- a/spec/command/host_factories_spec.rb
+++ b/spec/command/host_factories_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'conjur/command/host_factories'
+
+describe Conjur::Command::HostFactories, :logged_in => true do
+
+  describe_command 'hostfactory:create --as-group the-group hf1' do
+    let (:group) { double(:group, :exists? => true) }
+
+    it 'calls api.create_host_factory and prints the results' do
+      allow(Conjur::Command.api).to receive(:role).with("the-account:group:the-group").and_return group
+      expect_any_instance_of(Conjur::API).to receive(:create_host_factory).and_return '{}'
+      expect { invoke }.to write('{}')
+    end
+  end
+
+end

--- a/spec/command/variable_expiration_spec.rb
+++ b/spec/command/variable_expiration_spec.rb
@@ -25,7 +25,7 @@ describe Conjur::Command::Variables, :logged_in => true do
             :url => 'https://core.example.com/variables/foo/expiration',
             :headers => {},
             :payload => {:duration => duration}
-          }).and_return('{}')
+          }).and_return(double('response', :body => '{}'))
       end
       
       shared_examples 'it sets variable expiration' do 
@@ -73,12 +73,14 @@ describe Conjur::Command::Variables, :logged_in => true do
 
   context "getting variable expirations" do
     context "with valid arguments" do
+      let (:expected_params) { nil }
+      let (:expected_headers) { {}.tap {|h| h.merge!(:params => expected_params) if expected_params} }
       before do
         expect(RestClient::Request).to receive(:execute).with({
             :method => :get,
             :url => 'https://core.example.com/variables/expirations',
-            :headers => {}
-          }).and_return('[]')
+            :headers => expected_headers
+          }).and_return(double('response', :body => '[]'))
       end
 
       shared_examples 'it writes expiration list' do
@@ -92,14 +94,17 @@ describe Conjur::Command::Variables, :logged_in => true do
       end
 
       describe_command 'variable:expirations --days 1' do
+        let (:expected_params) { { :duration => 'P1D' } }
         it_behaves_like 'it writes expiration list' 
       end
 
       describe_command 'variable:expirations --months 1' do
+        let (:expected_params) { { :duration => 'P1M' } }
         it_behaves_like 'it writes expiration list' 
       end
 
       describe_command 'variable:expirations --in P1D' do
+        let (:expected_params) { { :duration => 'P1D' } }
         it_behaves_like 'it writes expiration list' 
       end
 

--- a/spec/command/variable_expiration_spec.rb
+++ b/spec/command/variable_expiration_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+require 'conjur/command/variables'
+
+describe Conjur::Command::Variables, :logged_in => true do
+  def invoke_silently
+    real_stderr = $stderr
+    $stderr = StringIO.new
+    begin
+      invoke
+    ensure
+      $stderr = real_stderr
+    end
+  end
+
+  let (:variable) { double(:name => 'foo') }
+  
+  context "expiring a variable" do
+    
+    let (:duration) { nil }
+
+    context "with valid arguments" do 
+      before do
+        expect(RestClient::Request).to receive(:execute).with({
+            :method => :post,
+            :url => 'https://core.example.com/variables/foo/expiration',
+            :headers => {},
+            :payload => {:duration => duration}
+          }).and_return('{}')
+      end
+      
+      shared_examples 'it sets variable expiration' do 
+        it do
+          expect {invoke}.to write
+        end
+      end
+      
+      describe_command 'variable:expire --now foo' do
+        let (:duration) { 'P0Y' }
+        it_behaves_like 'it sets variable expiration'
+      end
+      
+      describe_command 'variable:expire --days 1 foo' do
+        let (:duration) { 'P1D' }
+        it_behaves_like 'it sets variable expiration'
+      end
+      
+      describe_command 'variable:expire --months 1 foo' do
+        let (:duration) { 'P1M' }
+        it_behaves_like 'it sets variable expiration'
+      end
+
+      describe_command 'variable:expire --in PT1M foo' do
+        let (:duration) { 'PT1M' }
+        it_behaves_like 'it sets variable expiration'
+      end
+
+    end
+
+    describe_command 'variable:expire --now --days 1 foo' do
+      it "fails" do
+        expect { invoke_silently }.to raise_error GLI::CustomExit
+      end
+
+    end
+
+    describe_command 'variable:expire' do
+      it 'should fail' do
+        expect { invoke_silently }.to raise_error RuntimeError
+      end
+    end
+
+  end
+
+  context "getting variable expirations" do
+    context "with valid arguments" do
+      before do
+        expect(RestClient::Request).to receive(:execute).with({
+            :method => :get,
+            :url => 'https://core.example.com/variables/expirations',
+            :headers => {}
+          }).and_return('[]')
+      end
+
+      shared_examples 'it writes expiration list' do
+        it do
+          expect { invoke }.to write "[\n\n]\n"
+        end
+      end
+
+      describe_command 'variable:expirations' do
+        it_behaves_like 'it writes expiration list' 
+      end
+
+      describe_command 'variable:expirations --days 1' do
+        it_behaves_like 'it writes expiration list' 
+      end
+
+      describe_command 'variable:expirations --months 1' do
+        it_behaves_like 'it writes expiration list' 
+      end
+
+      describe_command 'variable:expirations --in P1D' do
+        it_behaves_like 'it writes expiration list' 
+      end
+
+    end
+
+    context "with invalid arguments" do
+      describe_command 'variable:expirations --days 1 --months 1' do
+        it 'should fail' do
+          expect { invoke_silently }.to raise_error GLI::CustomExit
+        end
+      end
+    end
+
+  end
+    
+end


### PR DESCRIPTION
**Needs to be merged after https://github.com/conjurinc/api-ruby/pull/59**

New support for expiration. Bring host-factory and audit-send commands in from their respective plugins.