### PR TITLE
Feature/retire layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 4.29.0
-
+* Add `conjur layer retire` to allow retiring a layer.
 * Add `cidr` commands to `user`, `host`, and `hostfactory token`
 * Move `audit send` and `host factory` commands from plugins into the core CLI
 * Add `variable expire` and `variable expirations` subcommands. Variable expirations is available in version 4.6 of the Conjur server.

--- a/acceptance-features/directory/layer/retire.feature
+++ b/acceptance-features/directory/layer/retire.feature
@@ -1,0 +1,43 @@
+Feature: Retire a layer
+  Background:
+    When I successfully run `conjur layer create $ns/applayer`
+
+  Scenario: Basic retirement
+    Then I successfully run `conjur layer retire -d user:attic@$ns $ns/applayer`
+
+  Scenario: Retiring a non-existent thing propagates the 404
+    Then I run `conjur layer retire -d user:attic@$ns $ns/foobar`
+    Then the exit status should be 1
+    And the stderr should contain "Resource Not Found"
+
+  Scenario: A foreign user can't retire a layer
+    Given I login as a new user
+    And I run `conjur layer retire -d user:attic@$ns $ns/applayer`
+    Then the exit status should be 1
+    And the stderr should contain "You can't administer this record"
+
+  Scenario: Can't retire to a non-existant role
+    And I run `conjur layer retire -d user:foobar $ns/applayer`
+    Then the exit status should be 1
+    And the output should match /error: Destination role/
+    And the output should match /doesn't exist$/
+
+  Scenario: I can retire a layer which I've granted to a group
+    Given I successfully run `conjur group create $ns/admin`
+    And I successfully run `conjur role grant_to layer:$ns/applayer group:$ns/admin`
+    Then I successfully run `conjur layer retire -d user:attic@$ns $ns/applayer`
+
+  Scenario: I can retire a layer which I've given to a group that I can admin
+    Given I successfully run `conjur group create $ns/admin`
+    And I successfully run `conjur resource give layer:$ns/applayer group:$ns/admin`
+    Then I successfully run `conjur layer retire -d user:attic@$ns $ns/applayer`
+
+  Scenario: I can't retire a layer if I can't admin the layer's role
+    Given I successfully run `conjur group create $ns/admin`
+    And I successfully run `conjur role grant_to layer:$ns/applayer group:$ns/admin`
+    Given I create a new user named "alice@$ns"
+    And I successfully run `conjur group members add -a $ns/admin alice@$ns`
+    And I login as "alice@$ns"
+    And I run `conjur layer retire -d user:attic@$ns $ns/applayer`
+    Then the exit status should be 1
+    And the stderr should contain "You can't administer this record"

--- a/lib/conjur/command.rb
+++ b/lib/conjur/command.rb
@@ -254,6 +254,22 @@ an alternative destination role.)
           obj.role.revoke_from member
         end
       end
+
+      def retire_internal_role roleObj
+        members = roleObj.members
+        # Move the invoking role to the end of the roles list, so that it doesn't
+        # lose its permissions in the middle of this operation.
+        self_member = members.select{|m| m.member.roleid == current_user.role.roleid}
+        self_member.each do |m|
+          members.delete m
+        end
+        members.concat self_member if self_member
+        members.each do |r|
+          member = api.role(r.member)
+          puts "Revoking from role #{member.roleid}"
+          roleObj.revoke_from member
+        end
+      end
       
       def give_away_resource obj, options
         destination = options[:"destination-role"]


### PR DESCRIPTION
retires the layer based on how we retire groups - but also retires internal roles for layers too. Examples of internal layers are:
role: "cucumber:@:layer/prod/analytics/v1/use_host"
role: "cucumber:@:layer/prod/analytics/v1/admin_host"
role: "cucumber:@:layer/prod/analytics/v1/observe”