### PR TITLE
policy -> rubydsl, mark deprecated

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 tmp
 *.deb
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Dockerfile.*
 .DS_Store
 *.swp
 *.deb

--- a/lib/conjur/cli.rb
+++ b/lib/conjur/cli.rb
@@ -110,6 +110,7 @@ module Conjur
 
     init!
 
+    program_desc 'Command-line toolkit for managing roles, resources and privileges'
     version Conjur::VERSION
 
     pre do |global,command,options,args|
@@ -134,7 +135,7 @@ module Conjur
         exit_now!("Role '#{as_role}' does not exist, or you don't have permission to use it") unless role.exists?
         options[:ownerid] = role.roleid
       end
-      
+
       true
     end
 
@@ -143,11 +144,11 @@ module Conjur
       code.call
       @current_command = nil
     end
-    
+
     on_error do |exception|
       require 'rest-client'
       require 'patches/conjur/error'
-        
+
       run_default_handler = true
       if @current_command != nil && !command_version_compatible?(@current_command)
         $stderr.puts "error: this command is not supported by the current Conjur server version"

--- a/lib/conjur/command/policy.rb
+++ b/lib/conjur/command/policy.rb
@@ -21,11 +21,12 @@
 require 'conjur/command/dsl_command'
 
 class Conjur::Command::Policy < Conjur::DSLCommand
-  desc "Manage policies"
-  command :policy do |policy|
+  desc "Manage Ruby DSL policies"
+  long_desc 'DEPRECATED. Declarative YML policy supercedes Ruby policy DSL.'
+  command :rubydsl do |policy|
     policy.desc "Load a policy from Conjur DSL"
     policy.long_desc <<-DESC
-Loads a Conjur policy from DSL, applying particular conventions to the role and resource
+Loads a Conjur policy from Ruby DSL, applying particular conventions to the role and resource
 ids.
 
 The first path element of each id is the collection. Policies can be separated into collections
@@ -74,19 +75,19 @@ owner of the policy role is the logged-in user (you), as always.
         policy = Policy.new(api.role(id), api.resource(id))
 
         validate_retire_privileges(policy, options)
-        
+
         retire_resource(policy)
-        
+
         # The policy resource is owned by the policy role. Having the
         # policy role is what allows us to administer it. So, we have
         # to give the resource away before we can revoke the role.
         give_away_resource(policy, options)
-        
+
         retire_role(policy)
 
         puts 'Policy retired'
       end
     end
-    
+
   end
 end

--- a/lib/conjur/command/rubydsl.rb
+++ b/lib/conjur/command/rubydsl.rb
@@ -20,12 +20,12 @@
 #
 require 'conjur/command/dsl_command'
 
-class Conjur::Command::Policy < Conjur::DSLCommand
-  desc "Manage Ruby DSL policies"
+class Conjur::Command::RubyDSL < Conjur::DSLCommand
+  desc "Manage Ruby DSL policies (deprecated)"
   long_desc 'DEPRECATED. Declarative YML policy supercedes Ruby policy DSL.'
-  command :rubydsl do |policy|
-    policy.desc "Load a policy from Conjur DSL"
-    policy.long_desc <<-DESC
+  command :rubydsl do |rubydsl|
+    rubydsl.desc "Load a policy from Conjur DSL"
+    rubydsl.long_desc <<-DESC
 Loads a Conjur policy from Ruby DSL, applying particular conventions to the role and resource
 ids.
 
@@ -41,8 +41,8 @@ annotations on the policy. The policy role becomes the owner of the owned policy
 --as-group and --as-role options can be used to set the owner of the policy role. The default
 owner of the policy role is the logged-in user (you), as always.
     DESC
-    policy.arg_name "FILE"
-    policy.command :load do |c|
+    rubydsl.arg_name "FILE"
+    rubydsl.command :load do |c|
       acting_as_option(c)
       collection_option(c)
       context_option(c)
@@ -62,9 +62,9 @@ owner of the policy role is the logged-in user (you), as always.
       end
     end
 
-    policy.desc 'Decommision a policy'
-    policy.arg_name 'POLICY'
-    policy.command :retire do |c|
+    rubydsl.desc 'Decommision a policy'
+    rubydsl.arg_name 'POLICY'
+    rubydsl.command :retire do |c|
       retire_options c
 
       c.action do |global_options, options, args |
@@ -72,18 +72,18 @@ owner of the policy role is the logged-in user (you), as always.
 
         # policy isn't a rolsource (yet), but we can pretend
         Policy = Struct.new(:role, :resource)
-        policy = Policy.new(api.role(id), api.resource(id))
+        rubydsl = Policy.new(api.role(id), api.resource(id))
 
-        validate_retire_privileges(policy, options)
+        validate_retire_privileges(rubydsl, options)
 
-        retire_resource(policy)
+        retire_resource(rubydsl)
 
         # The policy resource is owned by the policy role. Having the
         # policy role is what allows us to administer it. So, we have
         # to give the resource away before we can revoke the role.
-        give_away_resource(policy, options)
+        give_away_resource(rubydsl, options)
 
-        retire_role(policy)
+        retire_role(rubydsl)
 
         puts 'Policy retired'
       end

--- a/lib/conjur/command/script.rb
+++ b/lib/conjur/command/script.rb
@@ -21,7 +21,7 @@
 require 'conjur/command/dsl_command'
 
 class Conjur::Command::Script < Conjur::DSLCommand
-  desc "Execute Conjur DSL scripts"
+  desc "Execute Ruby DSL scripts"
   command :script do |script|
     script.desc "Run a Conjur DSL script"
     script.arg_name "script"

--- a/spec/command/rubydsl_spec.rb
+++ b/spec/command/rubydsl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'conjur/dsl/runner'
 
-describe Conjur::Command::Policy do
+describe Conjur::Command::RubyDSL do
   context "when logged in", logged_in: true do
     let(:role) do
       double("role", exists?: true, api_key: "the-api-key", roleid: "the-role")
@@ -22,8 +22,8 @@ describe Conjur::Command::Policy do
       allow(api).to receive(:role).with("the-account:policy:#{collection}/the-policy-1.0.0").and_return role
       allow(api).to receive(:resource).with("the-account:policy:#{collection}/the-policy-1.0.0").and_return resource
     }
-    
-    describe_command 'policy:load --collection the-collection http://example.com/policy.rb' do
+
+    describe_command 'rubydsl:load --collection the-collection http://example.com/policy.rb' do
       let(:collection) { "the-collection" }
       before {
         allow(File).to receive(:exists?).with("http://example.com/policy.rb").and_return false
@@ -33,7 +33,7 @@ describe Conjur::Command::Policy do
         expect(invoke).to eq(0)
       end
     end
-    describe_command 'policy:load --collection the-collection policy.rb' do
+    describe_command 'rubydsl:load --collection the-collection policy.rb' do
       let(:collection) { "the-collection" }
       it "creates the policy" do
         expect(invoke).to eq(0)
@@ -44,16 +44,16 @@ describe Conjur::Command::Policy do
       before {
         stub_const("ENV", "USER" => "alice", "HOSTNAME" => "localhost")
       }
-      describe_command 'policy:load --as-group the-group policy.rb' do
+      describe_command 'rubydsl:load --as-group the-group policy.rb' do
         let(:group) { double(:group, exists?: true) }
         it "creates the policy" do
           allow(Conjur::Command.api).to receive(:role).with("the-account:group:the-group").and_return group
           expect_any_instance_of(Conjur::DSL::Runner).to receive(:owner=).with("the-account:group:the-group")
-          
+
           expect(invoke).to eq(0)
         end
       end
-      describe_command 'policy:load policy.rb' do
+      describe_command 'rubydsl:load policy.rb' do
         it "creates the policy with default collection" do
           expect(invoke).to eq(0)
         end

--- a/spec/complete_spec.rb
+++ b/spec/complete_spec.rb
@@ -21,9 +21,7 @@ describe Conjur::CLI::Complete do
       end
 
       context 'with "conjur p"' do
-        it { expects_completions_for('p').to include 'plugin',
-                                                     'policy',
-                                                     'pubkeys' }
+        it { expects_completions_for('p').to include 'plugin', 'pubkeys' }
       end
 
       context 'with "conjur host l"' do
@@ -31,8 +29,8 @@ describe Conjur::CLI::Complete do
                                                           'list' }
       end
 
-      context 'with "conjur policy"' do
-        it { expects_completions_for('policy ').to include 'load' }
+      context 'with "conjur rubydsl"' do
+        it { expects_completions_for('rubydsl ').to include 'load' }
       end
     end
 


### PR DESCRIPTION
* Leave ‘script’ command as-is
* Rename ‘policy’ -> ‘rubydsl’, mark as deprecated
