### PR TITLE
Replace -r with --recipe-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Pass `--recipe-url` argument to Chef, which is now required
+
 # 5.1.2
 
 * Fix problem finding config files for plugin installation

--- a/features/conjurize.feature
+++ b/features/conjurize.feature
@@ -112,16 +112,16 @@ curl -L https://www.opscode.com/chef/install.sh | bash
 """
     And the output should match:
     """
-    chef-solo -r https:\/\/github.com\/conjur-cookbooks\/conjur\/releases\/download/v\d\.\d\.\d/conjur-v\d\.\d\.\d.tar.gz -o conjur
+    chef-solo --recipe-url https:\/\/github.com\/conjur-cookbooks\/conjur\/releases\/download/v\d\.\d\.\d/conjur-v\d\.\d\.\d.tar.gz -o conjur
     """
 
   Scenario: conjurize with arbitrary cookbook
     When I conjurize "--conjur-cookbook-url https://example.com --conjur-run-list fry"
-    Then the stdout should contain "chef-solo -r https://example.com -o fry"
+    Then the stdout should contain "chef-solo --recipe-url https://example.com -o fry"
 
   Scenario: conjurize with path to chef-solo
     When I conjurize "--chef-executable /path/to/chef-solo --conjur-cookbook-url https://example.com --conjur-run-list fry"
-    Then the stdout should contain "/path/to/chef-solo -r https://example.com -o fry"
+    Then the stdout should contain "/path/to/chef-solo --recipe-url https://example.com -o fry"
     And the stdout should not contain "curl -L https://www.opscode.com/chef/install.sh"
 
   Scenario: conjurize with sudo-ized commands

--- a/lib/conjur/conjurize/script.rb
+++ b/lib/conjur/conjurize/script.rb
@@ -81,7 +81,7 @@ set -e
       @chef_script ||= [
         ("curl -L https://www.opscode.com/chef/install.sh | " + sudo["bash"] \
           if install_chef?),
-        (sudo["#{chef_executable} -r #{conjur_cookbook_url} " \
+        (sudo["#{chef_executable} --recipe-url #{conjur_cookbook_url} " \
             "-o #{conjur_run_list}"] if run_chef?)
       ].join "\n"
     end


### PR DESCRIPTION
Otherwise Chef complains with:
```
WARN: -r MUST be changed to --recipe-url, the -r option will be changed in Chef 13.0 at
[...]/chef-12.9.41/lib/chef/application.rb:56:in `run'
```