### PR TITLE
Drop bundler dependency

### DIFF
--- a/conjur.gemspec
+++ b/conjur.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Conjur::VERSION
 
   gem.add_dependency 'activesupport', '~> 4.2'
-  gem.add_dependency 'bundler', '< 1.12.0'
   gem.add_dependency 'conjur-api', '~> 4.21'
   gem.add_dependency 'gli', '>=2.8.0'
   gem.add_dependency 'highline', '~> 1.7'


### PR DESCRIPTION
Conjur CLI doesn't actually use bundler at all. It's not clear to
me where this dependency comes from, but it's not required and
in conjunction with the strict version pin it makes some other gemsets
which depend on conjur-cli die horribly in flames.