### PR TITLE
Continuously keep a fresh access token in a file

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -19,5 +19,6 @@ services:
     environment:
       CONJUR_APPLIANCE_URL: http://possum
       CONJUR_ACCOUNT: cucumber
+    working_dir: /src/conjur-cli
     volumes:
     - ..:/src/conjur-cli

--- a/features/authentication/authenticate.feature
+++ b/features/authentication/authenticate.feature
@@ -17,3 +17,18 @@ Feature: Authenticate a role
     And I login as "alice"
     When I successfully run `conjur authn authenticate`
     Then the JSON at "data" should be "alice"
+
+  @announce-command
+  @announce-output
+  Scenario: The access token can be continuously refreshed in a file.
+    When I run `env CONJUR_TOKEN_LIFESPAN=2 CONJUR_TOKEN_REFRESH_DELAY=1 CONJURAPI_LOG=stderr conjur authn authenticate -f /tmp/token` interactively
+    And I run `sleep inf`
+    Then the output should contain:
+    """
+    Authenticating admin to account cucumber
+    Refreshed Conjur auth token to "/tmp/token"
+    Authenticating admin to account cucumber
+    Refreshed Conjur auth token to "/tmp/token"
+    Authenticating admin to account cucumber
+    Refreshed Conjur auth token to "/tmp/token"
+    """

--- a/lib/conjur/authenticator.rb
+++ b/lib/conjur/authenticator.rb
@@ -1,0 +1,76 @@
+module Conjur
+  # Keeps a fresh Conjur access token in a named file by re-authenticating as needed.
+  class Authenticator
+    TOKEN_LIFESPAN = ( ENV['CONJUR_TOKEN_LIFESPAN'] || 5 * 60 ).to_i.seconds
+    DELAY = ( ENV['CONJUR_TOKEN_REFRESH_DELAY'] || 10 ).to_i.seconds
+
+    attr_reader :authenticate, :filename
+
+    # +authenticate+ should be a proc that authenticates with Conjur and returns an 
+    # access token as a Hash.
+    def initialize authenticate, filename
+      @authenticate = authenticate
+      @filename = filename
+    end
+
+    class << self
+      def default_filename
+        "/etc/conjur-auth/token"
+      end
+
+      # Check the token every +DELAY+ seconds and refresh it if it's out of date. 
+      def run authenticate:, filename: default_filename
+        while true
+          authenticator = Authenticator.new(authenticate, filename)
+          authenticator.refresh unless authenticator.fresh?
+          sleep DELAY
+        end
+      end
+    end
+
+    def fresh?
+      token && (token_age <= TOKEN_LIFESPAN)
+    end
+
+    # Perform atomic replacement of the token
+    def refresh
+      token = authenticate.call
+      require 'fileutils'
+      temp_filename = File.join(directory, "token.#{random}")
+      File.write temp_filename, JSON.pretty_generate(token)
+      FileUtils.mv temp_filename, filename
+      Conjur.log << "Refreshed Conjur auth token to #{filename.inspect}\n" if Conjur.log
+    rescue
+      $stderr.puts $!
+    end
+
+    def token
+      return false if @token == false
+      @token ||= load_token
+    end
+
+    protected
+
+    def random nbytes = 12
+      @random ||= Random.new
+      @random.bytes(nbytes).unpack('h*').first
+    end
+
+    def directory
+      File.dirname(filename)
+    end
+
+    def load_token
+      return false unless File.file?(filename)
+      JSON.parse(File.read(filename)) rescue false
+    end
+
+    def token_born
+      File.mtime(filename)
+    end
+
+    def token_age
+      Time.now - token_born
+    end
+  end
+end

--- a/lib/conjur/cli.rb
+++ b/lib/conjur/cli.rb
@@ -37,6 +37,7 @@ module Conjur
   autoload :Log,                    'conjur/log'
   autoload :IdentifierManipulation, 'conjur/identifier_manipulation'
   autoload :Authn,                  'conjur/authn'
+  autoload :Authenticator,          'conjur/authenticator'
   autoload :Command,                'conjur/command'
   autoload :DSL,                    'conjur/dsl/runner'
   autoload :DSLCommand,             'conjur/command/dsl_command'

--- a/lib/conjur/config.rb
+++ b/lib/conjur/config.rb
@@ -90,17 +90,7 @@ module Conjur
           cfg.set k, value if value
         end
 
-        if Conjur.log
-          require 'conjur/api'
-          host = begin
-            Conjur::Authn::API.host
-          rescue RuntimeError
-            nil
-          end
-          if host
-            Conjur.log << "Using authn host #{Conjur::Authn::API.host}\n"
-          end
-        end
+        Conjur.log << "Using authn url #{Conjur.configuration.authn_url}\n" if Conjur.log
 
         Conjur.config.apply_cert_config!
       end


### PR DESCRIPTION
This is a building block for init container support.

